### PR TITLE
Added TailwindCSS as a CDN

### DIFF
--- a/Project/index/templates/index/base.html
+++ b/Project/index/templates/index/base.html
@@ -7,6 +7,7 @@
 <head>
     <meta charset="UTF-8">
     <title>{% block title %}EndoLink{% endblock %}</title>
+    <link href="https://unpkg.com/tailwindcss@^2/dist/tailwind.min.css" rel="stylesheet">
 </head>
 <body>
     {% if user.is_authenticated %}


### PR DESCRIPTION
Added TailwindCSS CDN to the project to allow contributors to use a consistent CSS framework whilst we figure out how to add Tailwind CSS to the front end build process.

We should definitely have Tailwind CSS as part of our build process for the following reasons explained on the page below.
https://tailwindcss.com/docs/installation#using-tailwind-via-cdn
