### PR TITLE
Added node_modules folder to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,5 @@ dmypy.json
 
 # IDE files
 .idea/
+
+**/node_modules


### PR DESCRIPTION
## Description
Fixes issue where node_modules folder was not included in . #gitignore file

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Docker containers still come up.
node_modules folder disappeared from pending changes in git.

## Checklist:

> Please check [x] all that apply.

- [x] My code follows similar styling to existing code in this project
- [x ] I have performed a self-review of my own code
- [x] I have commented my code, at the very least in hard-to-understand areas
- [x] I have made corresponding changes to documentation / READMEs
- [x] My changes generate no new warnings
- [x] I have remade my frontend and backend Docker containers to ensure my changes do not break the setup for these
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
