### PR TITLE
Add indexedDb with initialization

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -5380,6 +5380,11 @@
       "integrity": "sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==",
       "dev": true
     },
+    "idb": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/idb/-/idb-6.1.4.tgz",
+      "integrity": "sha512-DshI5yxIB3NYc47cPpfipYX8MSIgQPqVR+WoaGI9EDq6cnLGgGYR1fp6z8/Bq9vMS8Jq1bS3eWUgXpFO5+ypSA=="
+    },
     "ieee754": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -26,6 +26,7 @@
     "@fortawesome/free-regular-svg-icons": "^5.15.3",
     "@fortawesome/free-solid-svg-icons": "^5.15.3",
     "bootstrap": "^5.1.2",
+    "idb": "^6.1.4",
     "rxjs": "~6.6.0",
     "tslib": "^2.3.0",
     "zone.js": "~0.11.4"

--- a/frontend/src/app/app.component.ts
+++ b/frontend/src/app/app.component.ts
@@ -1,8 +1,19 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
+import { IndexedDbService } from './services/indexed-db/indexed-db.service';
 
 @Component({
   selector: 'app-root',
   templateUrl: './app.component.html',
   styleUrls: ['./app.component.scss']
 })
-export class AppComponent {}
+
+export class AppComponent implements OnInit {
+
+  constructor( private indexedDbService: IndexedDbService ) {
+    this.indexedDbService.init();
+  }
+
+  ngOnInit(): void {
+  }
+
+}

--- a/frontend/src/app/services/indexed-db/indexed-db.service.spec.ts
+++ b/frontend/src/app/services/indexed-db/indexed-db.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { IndexedDbService } from './indexed-db.service';
+
+describe('IndexedDbService', () => {
+  let service: IndexedDbService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(IndexedDbService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/frontend/src/app/services/indexed-db/indexed-db.service.ts
+++ b/frontend/src/app/services/indexed-db/indexed-db.service.ts
@@ -1,0 +1,49 @@
+import { Injectable } from '@angular/core';
+import { openDB, OpenDBCallbacks } from 'idb';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class IndexedDbService {
+
+  indexedDb: any;
+  storeName = "endolink"
+
+  constructor() {
+  }
+
+  init(): void {
+    if ( !( 'indexedDB' in window ) ) {
+      alert( 'IndexedDB is not supported in your browser!\n' +
+        'For user authentication to work it is recommended to use a Chromium-based browser or the latest version of Firefox.\n' +
+        'If you\'re seeing this error while using Internet Explorer, you deserve nothing less.' );
+    }
+
+    this.indexedDb = openDB( this.storeName, 1, {
+      upgrade( db ): void {
+        db.createObjectStore( 'keyval' );
+      }
+    } );
+  }
+
+  async get( key: string ): Promise<any> {
+    return ( await this.indexedDb  ).get( 'keyval', key );
+  }
+
+  async set( key: string, val: any ): Promise<any> {
+    return ( await this.indexedDb ).put( 'keyval', val, key );
+  }
+
+  async delete( key: string ): Promise<any> {
+    return ( await this.indexedDb ).delete( 'keyval', key );
+  }
+
+  async clear(): Promise<any> {
+    return ( await this.indexedDb ).clear( 'keyval' );
+  }
+
+  async keys(): Promise<any> {
+    return ( await this.indexedDb ).getAllKeys( 'keyval' );
+  }
+
+}


### PR DESCRIPTION
## Description

> Adds a service to interact with IndexedDB, a browser-based KeyVal-store for saving tokens and site settings (because cookies and localstorage are boring).

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- Initialization through the app-component works

## Checklist:

> Please check [x] all that apply.

- [x] My code follows similar styling to existing code in this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, at the very least in hard-to-understand areas
- [ ] I have made corresponding changes to documentation / READMEs
- [x] My changes generate no new warnings
- [x] I have remade my frontend and backend Docker containers to ensure my changes do not break the setup for these
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
