### PR TITLE
Fix for simplejwt issue 266

### DIFF
--- a/backend/account/admin.py
+++ b/backend/account/admin.py
@@ -1,5 +1,7 @@
 from django.contrib import admin
 from .models import UserExtraInfo
+from rest_framework_simplejwt import token_blacklist
+
 
 # Register your models here.
 
@@ -9,3 +11,15 @@ class UserExtraInfoAdmin(admin.ModelAdmin):
 
 
 admin.site.register(UserExtraInfo, UserExtraInfoAdmin)
+
+
+# The following is a fix for an issue with the rest_framework_simplejwt blacklist app.
+# As per: https://github.com/jazzband/djangorestframework-simplejwt/issues/266
+class OutstandingTokenAdmin(token_blacklist.admin.OutstandingTokenAdmin):
+
+    def has_delete_permission(self, *args, **kwargs):
+        return True
+
+
+admin.site.unregister(token_blacklist.models.OutstandingToken)
+admin.site.register(token_blacklist.models.OutstandingToken, OutstandingTokenAdmin)


### PR DESCRIPTION
## Description

> Please include a summary of the change and which issue is resolved. List any dependencies that are required for this change.

Users with outstanding tokens cannot be deleted if the simplejwt token blacklist app is enabled. This is because outstanding tokens override admin permissions. This fix overrides that and gives admins permission to delete outstanding tokens (and as such; permission to delete users with outstanding tokens).

More info: https://github.com/jazzband/djangorestframework-simplejwt/issues/266

## Type of change

> Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

> Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- Deleted user with outstanding tokens.

## Checklist:

> Please check [x] all that apply.

- [x] My code follows similar styling to existing code in this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, at the very least in hard-to-understand areas
- [ ] I have made corresponding changes to documentation / READMEs
- [x] My changes generate no new warnings
- [x] I have remade my frontend and backend Docker containers to ensure my changes do not break the setup for these
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
